### PR TITLE
Reimplement macros using spec conform and unform

### DIFF
--- a/src/net/danielcompton/defn_spec_alpha/macros.clj
+++ b/src/net/danielcompton/defn_spec_alpha/macros.clj
@@ -105,155 +105,93 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helpers for schematized fn/defn
 
-(defn split-rest-arg [env bind]
-  (let [[pre-& [_ rest-arg :as post-&]] (split-with #(not= % '&) bind)]
-    (if (seq post-&)
-      (do (assert! (= (count post-&) 2) "& must be followed by a single binding" (vec post-&))
-          (assert! (or (symbol? rest-arg)
-                       (and (vector? rest-arg)
-                            (not-any? #{'&} rest-arg)))
-                   "Bad & binding form: currently only bare symbols and vectors supported" (vec post-&))
+(defn nil->any? [spec]
+  (if (nil? spec) 'any?
+      spec))
 
-          [(vec pre-&)
-           (if (vector? rest-arg)
-             (with-meta (process-arrow-schematized-args env rest-arg) (meta rest-arg))
-             rest-arg)])
-      [bind nil])))
+(defn nils->any? [specs]
+  (map nil->any? specs))
 
-(defn single-arg-schema-form [rest? [index arg]]
-  `(~(if rest? `schema.core/optional `schema.core/one)
-     ~(extract-schema-form arg)
-     ~(if (symbol? arg)
-        `'~arg
-        `'~(symbol (str (if rest? "rest" "arg") index)))))
 
-(defn simple-arglist-schema-form [rest? regular-args]
-  (mapv (partial single-arg-schema-form rest?) (map-indexed vector regular-args)))
+(defn gen-argument-keys [args]
+  "Given a list of arguments obtained by conforming the ::annotated-defn-args spec,
+   generate a list of keywords to label the spec in s/cat. Because map destructures are
+   sometimes anonymous and seq destructures are always anonymous, we generate unique keys
+   to annote them and aid in legibility when functions are instrumented."
+  (let [keys-accumulator
+        (reduce (fn [acc [type params]]
+                  (case type
+                    :local-symbol (update acc :arg-keys conj (keyword (:local-name params)))
+                    :map-destructure (-> acc
+                                         (update :arg-keys
+                                                 conj
+                                                 (keyword
+                                                  (keyword (str "map-destructure-" (:map-destructure-count acc)))))
+                                         (update :map-destructure-count inc))
+                    :seq-destructure (-> acc
+                                         (update :arg-keys
+                                                 conj
+                                                 (keyword (str "seq-destructure-" (:seq-destructure-count acc))))
+                                         (update :seq-destructure-count inc))))
+                {:map-destructure-count 1
+                 :seq-destructure-count 1
+                 :arg-keys []}
+                args)]
+    (:arg-keys keys-accumulator)))
 
-(defn rest-arg-schema-form [arg]
-  (let [s (extract-schema-form arg)]
-    (if (= s `schema.core/Any)
-      (if (vector? arg)
-        (simple-arglist-schema-form true arg)
-        [`schema.core/Any])
-      (do (assert! (vector? s) "Expected seq schema for rest args, got %s" s)
-          s))))
-
-(defn input-schema-form [regular-args rest-arg]
-  (let [base (simple-arglist-schema-form false regular-args)]
-    (if rest-arg
-      (vec (concat base (rest-arg-schema-form rest-arg)))
-      base)))
-
-(defn apply-prepost-conditions
-  "Replicate pre/postcondition logic from clojure.core/fn."
-  [body]
-  (let [[conds body] (maybe-split-first #(and (map? %) (next body)) body)]
-    (concat (map (fn [c] `(assert ~c)) (:pre conds))
-            (if-let [post (:post conds)]
-              `((let [~'% (do ~@body)]
-                  ~@(map (fn [c] `(assert ~c)) post)
-                  ~'%))
-              body))))
-
-(def ^:dynamic *compile-fn-validation* (atom true))
-
-(defn compile-fn-validation?
-  "Returns true if validation should be included at compile time, otherwise false.
-   Validation is elided for any of the following cases:
-   *   function has :never-validate metadata
-   *   *compile-fn-validation* is false
-   *   *assert* is false AND function is not :always-validate"
-  [env fn-name]
-  (let [fn-meta (meta fn-name)]
-    (and
-      @*compile-fn-validation*
-      (not (:never-validate fn-meta))
-      (or (:always-validate fn-meta)
-          *assert*))))
-
-(defn process-fn-arity
-  "Process a single (bind & body) form, producing an output tag, schema-form,
-   and arity-form which has asserts for validation purposes added that are
-   executed when turned on, and have very low overhead otherwise.
-   tag? is a prospective tag for the fn symbol based on the output schema.
-   schema-bindings are bindings to lift eval outwards, so we don't build the schema
-   every time we do the validation."
-  [env fn-name output-schema-sym bind-meta [bind & body]]
-  (assert! (vector? bind) "Got non-vector binding form %s" bind)
-  (when-let [bad-meta (seq (filter (or (meta bind) {}) [:tag :s? :s :spec]))]
-    (throw (RuntimeException. (str "Meta not supported on bindings, put on fn name" (vec bad-meta)))))
-  (let [original-arglist bind
-        ;; this returns symbols with metadata on them
-        bind (with-meta (process-arrow-schematized-args env bind) bind-meta)
-        [regular-args rest-arg] (split-rest-arg env bind)
-        input-schema-sym (gensym "input-schema")
-        input-checker-sym (gensym "input-checker")
-        output-checker-sym (gensym "output-checker")
-        compile-validation (compile-fn-validation? env fn-name)]
-    {:schema-binding [input-schema-sym (input-schema-form regular-args rest-arg)]
-     :more-bindings  (when compile-validation
-                       [input-checker-sym `(delay (schema.core/checker ~input-schema-sym))
-                        output-checker-sym `(delay (schema.core/checker ~output-schema-sym))])
-     :arglist        bind
-     :raw-arglist    original-arglist
-     :arity-form     (if compile-validation
-                       (let [bind-syms (vec (repeatedly (count regular-args) gensym))
-                             rest-sym (when rest-arg (gensym "rest"))
-                             metad-bind-syms (with-meta (mapv #(with-meta %1 (meta %2)) bind-syms bind) bind-meta)]
-                         (list
-                           (if rest-arg
-                             (into metad-bind-syms ['& rest-sym])
-                             metad-bind-syms)
-                           `(let [o# (loop ~(into (vec (interleave (map #(with-meta % {}) bind) bind-syms))
-                                                  (when rest-arg [rest-arg rest-sym]))
-                                       ~@(apply-prepost-conditions body))]
-                              o#)))
-                       (cons (into regular-args (when rest-arg ['& rest-arg]))
-                             body))}))
-
-(defn process-fn-
-  "Process the fn args into a final tag proposal, schema form, schema bindings, and fn form"
-  [env name fn-body]
-  (let [compile-validation (compile-fn-validation? env name)
-        output-schema (extract-schema-form name)
-        output-schema-sym (gensym "output-schema")
-        bind-meta (or (when-let [t (:tag (meta name))]
-                        (when (primitive-sym? t)
-                          {:tag t}))
-                      {})
-        processed-arities (map (partial process-fn-arity env name output-schema-sym bind-meta)
-                               (if (vector? (first fn-body))
-                                 [fn-body]
-                                 fn-body))
-        schema-bindings (map :schema-binding processed-arities)
-        fn-forms (map :arity-form processed-arities)]
-    {:outer-bindings (vec (concat
-                            [output-schema-sym output-schema]
-                            (apply concat schema-bindings)
-                            (mapcat :more-bindings processed-arities)))
-     :arglists       (map :arglist processed-arities)
-     :raw-arglists   (map :raw-arglist processed-arities)
-     :schema-form    (if (= 1 (count processed-arities))
-                       `(schema.core/->FnSchema ~output-schema-sym ~[(ffirst schema-bindings)])
-                       `(schema.core/make-fn-schema ~output-schema-sym ~(mapv first schema-bindings)))
-     :fn-body        fn-forms
-     :processed-arities processed-arities}))
+(defn arity-labels []
+  (map (fn [x] (keyword (str "arity-" x))) (iterate inc 1)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public: helpers for schematized functions
 
-(defn normalized-defn-args
-  "Helper for defining defn-like macros with schemas.  Env is &env
-   from the macro body.  Reads optional docstring, return type and
-   attribute-map and normalizes them into the metadata of the name,
-   returning the normalized arglist.  Based on
-   clojure.tools.macro/name-with-attributes."
-  [env macro-args]
-  (let [[name macro-args] (extract-arrow-schematized-element env macro-args)
-        [maybe-docstring macro-args] (maybe-split-first string? macro-args)
-        [maybe-attr-map macro-args] (maybe-split-first map? macro-args)]
-    (cons (vary-meta name merge
-                     (or maybe-attr-map {})
-                     (when maybe-docstring {:doc maybe-docstring}))
-          macro-args)))
+(defn combine-arg-specs [{:keys [fn-tail]}]
+  ;; In the event of arity-1, check if anything is specified at all. If not, return nil
+  ;; If so, run through each form, generating either the annotation with label or the
+  ;; label with any?
+  (case (first fn-tail)
+    :arity-1
+    (let [{:keys [args varargs]} (:params (last fn-tail))
+          arg-specs (into [] (map #(get-in (last %) [:annotation :spec])) args)
+          arg-names (gen-argument-keys args)
+          vararg-spec (-> varargs
+                          :form
+                          last
+                          :annotation
+                          :spec)]
+      ;; If no arguments are specced, return nil
+      (when (some identity (conj arg-specs vararg-spec))
+        (let [specced-args (vec (interleave arg-names (nils->any? arg-specs)))]
+          (if varargs
+            `(s/cat ~@specced-args :vararg (s/* ~(nil->any? vararg-spec)))
+            `(s/cat ~@specced-args)))))
+    :arity-n
+    (let [{:keys [bodies]} (last fn-tail)
+          params (map :params bodies)
+          arg-lists (map :args params)
+          vararg-lists (map :varargs params)
+          arg-specs (map (fn [arglist]
+                           (map (fn [arg]
+                                  (get-in (last arg) [:annotation :spec]))
+                                arglist)) arg-lists)
+          vararg-specs (map (fn [vararg-list]
+                              (map (fn [vararg]
+                                     (-> vararg :form last :annotation :spec)) vararg-list)) vararg-lists)]
+      ;; If no arguments are specced, return nil
+      (when (some identity (conj (flatten arg-specs) (flatten vararg-specs)))
+        `(s/or
+          ~@(interleave (arity-labels)
+                        (map (fn [arg-list vararg]
+                               (let [arg-specs (into [] (comp (map #(get-in (last %) [:annotation :spec]))
+                                                              (map nil->any?)) arg-list)
+                                     vararg-spec (-> vararg
+                                                     :form
+                                                     last
+                                                     :annotation
+                                                     :spec)
+                                     arg-names (gen-argument-keys arg-list)]
+                                 (let [specced-args (vec (interleave arg-names arg-specs))]
+                                   (if vararg
+                                     `(s/cat ~@specced-args :varargs (s/* ~(nil->any? vararg-spec)))
+                                     `(s/cat ~@specced-args)))))
+                             arg-lists vararg-lists)))))))

--- a/src/net/danielcompton/defn_spec_alpha/spec.clj
+++ b/src/net/danielcompton/defn_spec_alpha/spec.clj
@@ -1,0 +1,170 @@
+(ns net.danielcompton.defn-spec-alpha.spec
+  "Here, two top-level specs are defined:
+  ::defn-args, which is similar to the one defined in core.specs.alpha, but modified so that unform is the inverse
+  of conform.
+
+  ::annotated-defn-args, which defines the syntax of the defn-spec-alpha defn macro including spec annotations
+
+  The original specs are specified here:
+  https://github.com/clojure/core.specs.alpha/blob/master/src/main/clojure/clojure/core/specs/alpha.clj
+
+  We've altered them according to https://blog.klipse.tech/clojure/2019/03/08/spec-custom-defn.html which
+  in turn cites https://github.com/Engelberg/better-cond"
+  (:require [clojure.spec.alpha :as s]
+            [clojure.walk :as walk]))
+
+(defn arg-list-unformer
+  "The original param-list spec unforms function args as a seq and wraps & destructured args in another seq.
+  Ensure args are unformed as a vector and & destructured forms are spliced into the args form."
+  [arg]
+  (vec 
+   (if (and (coll? (last arg)) (= '& (first (last arg))))
+     (concat (drop-last arg) (last arg))
+     arg)))
+
+;; ::defn-args supporting specs
+
+(s/def ::seq-binding-form
+  (s/and vector?
+         (s/conformer identity vec)
+         (s/cat :forms (s/* ::binding-form)
+                :rest-forms (s/? (s/cat :ampersand #{'&} :form ::binding-form))
+                :as-form (s/? (s/cat :as #{:as} :as-sym ::local-name)))))
+
+(s/def ::map-special-binding
+  (s/keys :opt-un [::as ::or ::keys ::syms ::strs]))
+
+(s/def ::ns-keys
+  (s/tuple
+    (s/and qualified-keyword? #(-> % name #{"keys" "syms"}))
+    (s/coll-of simple-symbol? :kind vector?)))
+
+(s/def ::map-binding (s/tuple ::binding-form any?))
+
+(s/def ::map-bindings
+  (s/every (s/or :map-binding ::map-binding
+                 :qualified-keys-or-syms ::ns-keys
+                 :special-binding (s/tuple #{:as :or :keys :syms :strs} any?)) :kind map?))
+
+(s/def ::map-binding-form (s/merge ::map-bindings ::map-special-binding))
+
+(s/def ::binding-form
+  (s/or :local-symbol ::local-name
+        :seq-destructure ::seq-binding-form
+        :map-destructure ::map-binding-form))
+
+(s/def ::param-list
+       (s/and
+        vector?
+        (s/conformer identity arg-list-unformer)
+        (s/cat :args (s/* ::binding-form)
+               :varargs (s/? (s/cat :amp #{'&} :form ::binding-form)))))
+
+(s/def ::params+body
+  (s/cat :params ::param-list
+         :body (s/alt :prepost+body (s/cat :prepost map?
+                                           :body (s/+ any?))
+                      :body (s/* any?))))
+
+(s/def ::defn-args
+  (s/cat :fn-name simple-symbol?
+         :docstring (s/? string?)
+         :meta (s/? map?)
+         :fn-tail (s/alt :arity-1 ::params+body
+                         :arity-n (s/cat :bodies (s/+ (s/spec ::params+body))
+                                         :attr-map (s/? map?)))))
+
+;; ::annotated-defn-args suppporting specs
+
+(s/def ::spec-annotation (s/cat :spec-literal #{:-} :spec any?))
+
+(defn annotated-arg-list-unformer [a]
+  (let [args-form (->> a
+                       (arg-list-unformer)
+                       (map (fn [x]
+                              (cond (not (seq? x)) (list x)
+                                    (map? x) (list x)
+                                    :else x))))]
+    (vec (apply concat args-form))))
+
+(defn annotated-defn-unformer
+  "Splice annotated forms into their parent expression rather than
+  nesting them as an additional seq.
+
+  Without an unformer (defn a :- int? [b c] (+ b c)), when conformed
+  and unformed again, would produce (defn a (:- int?) ...) where we
+  want (defn a :- int ...)"
+  [a]
+  (if (and (coll? a) (= :- (first (first (rest a)))))
+    (concat (take 1 a) (first (rest a)) (rest (rest a)))
+    a))
+
+(s/def ::local-name (s/and simple-symbol? #(not= '& %)))
+
+(s/def ::annotated-map-binding-form (s/merge ::map-bindings ::map-special-binding))
+
+(s/def ::annotated-binding-form
+  (s/alt :local-symbol (s/cat :local-name ::local-name
+                              :annotation (s/? (s/cat :spec-literal #{:-} :spec any?)))
+         :seq-destructure (s/cat :seq-binding-form ::seq-binding-form
+                                 :annotation (s/? (s/cat :spec-literal #{:-} :spec any?)))
+         :map-destructure (s/cat :map-binding-form ::map-binding-form
+                                 :annotation (s/? (s/cat :spec-literal #{:-} :spec any?)))))
+
+(s/def ::annotated-param-list
+  (s/and
+   vector?
+   (s/conformer identity annotated-arg-list-unformer)
+   (s/cat :args (s/* ::annotated-binding-form)
+          :varargs (s/? (s/cat :amp #{'&} :form ::annotated-binding-form)))))
+
+(s/def ::annotated-params+body
+  (s/cat :params ::annotated-param-list
+         :body (s/alt :prepost+body (s/cat :prepost map?
+                                           :body (s/+ any?))
+                      :body (s/* any?))))
+
+(s/def ::annotated-defn-args
+  (s/and
+   (s/conformer identity annotated-defn-unformer)
+   (s/cat :fn-name simple-symbol?
+          :ret-annotation (s/? ::spec-annotation)
+          :docstring (s/? string?)
+          :meta (s/? map?)
+          :fn-tail (s/alt :arity-1 ::annotated-params+body
+                          :arity-n (s/cat :bodies (s/+ (s/spec ::annotated-params+body))
+                                          :attr-map (s/? map?))))))
+
+
+(defn- annotated-args->args
+  "Strip annotation from an args AST node"
+  [ast]
+  (walk/postwalk (fn [x]
+                   (cond (and (map-entry? x) (= :local-symbol (key x)) (not (symbol? (val x))))
+                         [:local-symbol (:local-name (last x))]
+                         (and (map-entry? x) (= :map-destructure (key x)))
+                         [:map-destructure (:map-binding-form (last x))]
+                         (and (map-entry? x) (= :seq-destructure (key x)))
+                         [:seq-destructure (:seq-binding-form (last x))]
+                         :else x)) ast))
+
+(defn- annotated-varargs->args
+  "Strip annotation from a varargs AST node"
+  [ast]
+  (walk/postwalk (fn [x]
+                   (cond (and (coll? x) (:annotation x)) (dissoc x :annotation)
+                         (and (map-entry? x) (= :local-symbol (key x)) (:local-name (val x)))
+                         [:local-symbol (:local-name (val x))]
+                         (and (map-entry? x) (= :seq-binding-form (key x))) (val x)
+                         :else x)) ast))
+
+(defn annotated-defn->defn
+  "Given an AST obtained from conforming an annotated defn, transform it into an AST that can
+  unform into a defn without annotation."
+  [ast]
+  (walk/prewalk (fn [x]
+                  (cond (and (map-entry? x) (= :args (key x))) (annotated-args->args x)
+                        (and (map-entry? x) (= :varargs (key x))) (annotated-varargs->args x)
+                        :else x)) ast))
+
+

--- a/test/net/danielcompton/defn_spec_alpha_test.clj
+++ b/test/net/danielcompton/defn_spec_alpha_test.clj
@@ -1,9 +1,10 @@
 (ns net.danielcompton.defn-spec-alpha-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer :all]
             [net.danielcompton.defn-spec-alpha :as ds]
-            [orchestra.spec.test :as st]
-            [clojure.spec.alpha :as s])
-  (:import (clojure.lang ExceptionInfo)))
+            [net.danielcompton.defn-spec-alpha.spec :as spec]
+            [orchestra.spec.test :as st])
+  (:import clojure.lang.ExceptionInfo))
 
 (use-fixtures :each
               (fn [f]
@@ -18,6 +19,46 @@
   (some-> p get-spec s/describe))
 
 (s/def ::int int?)
+
+;; spec tests
+
+(defn conform-unform [sexpr]
+  (->> sexpr
+       (s/conform ::spec/defn-args)
+       (s/unform ::spec/defn-args)))
+
+(defn annotated-conform-unform [sexpr]
+  (->> sexpr
+       (s/conform ::spec/annotated-defn-args)
+       (s/unform ::spec/annotated-defn-args)))
+
+(deftest conform-is-the-inverse-of-unform
+  (testing "defn spec"
+    (let [single-arity '(a [x] x)
+          keys-destructuring '(b [{:keys [a b c]}] (+ b c))
+          seq-destructuring '(c [[a b] c] (+ a c))
+          and-destructuring '(d [a & xs] xs)
+          multiple-arities '(e ([a] a) ([a {:keys [b c]}] (+ b c)) ([a & xs] xs) ([[c d]] (+ c d)))]
+      (are [original unformed] (= original unformed)
+        single-arity (conform-unform single-arity)
+        keys-destructuring (conform-unform keys-destructuring)
+        seq-destructuring (conform-unform seq-destructuring)
+        and-destructuring (conform-unform and-destructuring)
+        multiple-arities (conform-unform multiple-arities))))
+  (testing "annotated defn spec"
+    (let [only-ret '(a :- int? [b] b)
+          no-ret '(a :- int? [b :- int?] b)
+          map-destructuring '(a :- int? [{:keys [b c]} :- map?]
+                                (+ b c))
+          seq-destructuring '(a :- int? [& xs :- any?]
+                                (apply + xs))]
+      (are [original] (= original (annotated-conform-unform original))
+        only-ret
+        no-ret
+        map-destructuring
+        seq-destructuring))))
+
+;; function definition tests
 
 (ds/defn arg-1-fn [x :- int?]
   x)
@@ -61,15 +102,13 @@
 
 (deftest args-ret-test
   (is (= 5 (args-ret 5)))
-  (is (thrown? ExceptionInfo
-               (args-ret-broken 5))))
+  (is (thrown? ExceptionInfo (args-ret-broken 5))))
 
 (deftest spec-forms-test
   (is (= (maybe-describe `args-ret)
          '(fspec :args (cat :x ::int) :ret int? :fn nil)))
 
-  ;; TODO: shouldn't define any :args spec if none is provided, #1
-  #_(is (= (maybe-describe `ret-spec)
+  (is (= (maybe-describe `ret-spec)
          '(fspec :args nil :ret ::int :fn nil)))
 
   (is (= (maybe-describe `arg-2)
@@ -92,56 +131,81 @@
 (deftest multi-arity-test
   (testing "works with no specs"
     (is (= 0 (multi-arity)))
-    ;; TODO: not working yet, see #2
-    #_(is (= 1 (multi-arity nil)))
-    #_(is (= 2 (multi-arity nil nil)))
-    #_(is (= 3 (multi-arity nil nil nil))))
+    (is (= 1 (multi-arity nil)))
+    (is (= 2 (multi-arity nil nil)))
+    (is (= 3 (multi-arity nil nil nil))))
 
   (testing "works with specs"
     (is (= (multi-arity-spec) 0))
-    #_(is (= (multi-arity-spec 5) 1))))
+    (is (= (multi-arity-spec 5) 1))
+    (is (thrown? ExceptionInfo (multi-arity-spec :x)))))
 
-; TODO: Broken, see #3
-;(ds/defn rest-destructuring-1
-;  [& rest]
-;  rest)
-;
-;(ds/defn rest-destructuring-2 [head & tail]
-;  [head tail])
-;
-;(deftest rest-destructuring-test)
+(ds/defn rest-destructuring-1
+  [& rest]
+  rest)
 
-; TODO: Broken, see #4
-;(ds/defn destructuring-list :- ::int
-;  [a :- ::int b :- int? & [c d]]
-;  [a b c d])
+(ds/defn rest-destructuring-2 [head & tail]
+  [head tail])
+
+(ds/defn multi-arity-varargs
+  ([x]
+   x)
+  ([x y z & rest]
+   [x y z rest]))
+
+(ds/defn destructuring-list :- ::int
+  [a :- ::int b :- int? & [c d]]
+  [a b c d])
+
+(ds/defn annotated-vararg-destructuring :- string?
+  [a :- string? & rest]
+  (apply str a rest))
 
 
-; TODO: Broken, see #10
-;(s/def ::foo string?)
-;(s/def ::keys-test (s/keys :req-un [::int ::foo]))
+;; Should we support annotation on the RHS of an &?
+#_(ds/defn annotated-seq-destructuring :- string?
+  [a :- string? & rest :- (s/coll-of string?)]
+    (apply str a rest))
+
+(ds/defn annotated-seq-destructuring :- ::int
+  [[a b] :- (s/coll-of ::int)]
+  (+ a b))
+
+(deftest varargs-tests
+  (is (= '(1 2 3) (rest-destructuring-1 1 2 3)))
+  (is (= [1 '(2 3)] (rest-destructuring-2  1 2 3)))
+  (is (= 3 (annotated-seq-destructuring [1 2])))
+  (testing "multi-arity varargs"
+    (is (= 1 (multi-arity-varargs 1)))
+    (is (thrown? ExceptionInfo (multi-arity-varargs 1 2)))
+    (is (= [1 2 3 nil] (multi-arity-varargs 1 2 3)))
+    (is (= [1 2 3 [4]] (multi-arity-varargs 1 2 3 4)))
+    (is (= [1 2 3 [4 5]] (multi-arity-varargs 1 2 3 4 5))))
+  (is (thrown? ExceptionInfo (annotated-seq-destructuring [1 :x]))))
+
+(s/def ::foo string?)
+(s/def ::keys-test (s/keys :req-un [::int ::foo]))
+
+
+(ds/defn keys-destructuring-unnamed :- (s/coll-of any?)
+  [{:keys [int foo]} :- ::keys-test]
+  [int foo])
+
+(ds/defn keys-destructuring-named
+  [{:keys [int foo] :as test-map} :- ::keys-test]
+  [int foo])
+
+
+(deftest keys-destructuring-test
+  (testing "destructuring maps without an :as"
+    (is (= (keys-destructuring-unnamed {:int 1 :foo "hi"}) [1 "hi"]))
+    (is (thrown? ExceptionInfo
+                 (keys-destructuring-unnamed {:int 5 :foo 5}))))
 ;
-;; Speccing keys
-;(ds/defn keys-destructuring-unnamed
-;  [{:keys [int foo]} :- ::keys-test]
-;  [int foo])
-;
-;(ds/defn keys-destructuring-named
-;  [{:keys [int foo] :as test-map} :- ::keys-test]
-;  [int foo])
-;
-;
-;(deftest keys-destructuring-test
-;  (testing "destructuring maps without an :as"
-;    (is (= (keys-destructuring-unnamed {:int 1 :foo "hi"}) [1 "hi"]))
-;    (is (thrown? ExceptionInfo
-;                 (keys-destructuring-unnamed {:int 5 :foo 5}))))
-;
-;  (testing "destructuring maps with an :as"
-;    (is (= (keys-destructuring-named {:int 1 :foo "hi"}) [1 "hi"]))
-;    (is (thrown? ExceptionInfo
-;                 (keys-destructuring-named {:int 5 :foo 5}))))
-;  )
+  (testing "destructuring maps with an :as"
+    (is (= (keys-destructuring-named {:int 1 :foo "hi"}) [1 "hi"]))
+    (is (thrown? ExceptionInfo
+                 (keys-destructuring-named {:int 5 :foo 5})))))
 
 
 (clojure.core/defn standard-defn [x]
@@ -172,8 +236,5 @@
     (is (some? (get-spec `only-ret)))))
 
 (comment
-  (s/describe (get @@#'clojure.spec.alpha/registry-ref `arg-1-spec))
-
-
-  )
+  (s/describe (get @@#'clojure.spec.alpha/registry-ref `arg-1-spec)))
 


### PR DESCRIPTION
This patch came out of a conversation around resolving #2, #3, #8, #10, and restoring annotation to map destructuring. In order to reduce the complexity of the parsing logic and to clearly specify the annotated form, I rewrote that macro logic in 3 layers:

- The actual macro form, housed in `net.danielcompton.defn-spec-alpha` now does almost nothing, invoking some helpers.

- The specs and their utilities, in `net.danielcompton.defn-spec-alpha.spec`, which provide a spec for the Clojure `defn` form and the `defn-spec-alpha/defn` form. Both specs are designed to conform and unform, allowing us to transform the form into an AST. Additionally there are functions that map the annotated AST to the defn AST so we can "translate" one to the other.

- Macro helpers, in `net.danielcompton.defn-spec.alpha.macros`, which turn specified args into `fdef` forms to annotate a function.

This leads to a workflow where we parse an annotated `defn` form into an AST, convert that AST into a raw `defn` form, parse annotations into an `fdef` form for validation and instrumentation, finally emitting the `defn` and `fdef`.

Fixes:
- Map destructuring forms can be annotated
- Seq destructuring forms can be annotated
- Multi-arity forms can be annotated

Regresssions:
- Docstring generation is gone but shouldn't be too difficult to restore, largely a question of whether we just append spec forms onto the existing docstring or do something more involved.

Future fixes:
- `& rest` forms cannot currently be annotated, but it shouldn't be a difficult addition.